### PR TITLE
Show recipe queries on recipe show page

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,7 +7,7 @@ class RecipesController < ApplicationController
              end
 
     if recipe
-      @recipe = RecipesHelper.saved_recipe_from_api(recipe)
+      @recipe = RecipesHelper.recipe_dto_from_api(recipe)
     else
       # can redirect back to user dashboard once implemented for favorites,
       # user dashboard for saved recipes

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,11 +1,23 @@
 class RecipesController < ApplicationController
   def show
-    recipe = Recipe.find_by_id(params[:id])
+    # recipe = Recipe.find_by_id(params[:id]) || Recipe.new(params[:edamam_uri],
+    #  params[:name])
+    if params[:name]
+      recipe = Recipe.new(params[:edamam_uri], params[:name])
+    else
+      recipe = Recipe.find_by_id(params[:id])
+    end
     if recipe
       @recipe = RecipesHelper.saved_recipe_from_api(recipe)
     else
       # can redirect back to user dashboard once implemented
       redirect_to action: 'show', id: 1, status: :not_found
     end
+  end
+
+  private
+
+  def recipe_params
+    params.require(:recipe).permit(:name, :edamam_uri)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -5,6 +5,7 @@ class RecipesController < ApplicationController
              else
                Recipe.find_by_id(params[:id])
              end
+
     if recipe
       @recipe = RecipesHelper.saved_recipe_from_api(recipe)
     else
@@ -12,11 +13,5 @@ class RecipesController < ApplicationController
       # user dashboard for saved recipes
       redirect_to action: 'show', id: 1, status: :not_found
     end
-  end
-
-  private
-
-  def recipe_params
-    params.require(:recipe).permit(:name, :edamam_id)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,16 +1,15 @@
 class RecipesController < ApplicationController
   def show
-    # recipe = Recipe.find_by_id(params[:id]) || Recipe.new(params[:edamam_uri],
-    #  params[:name])
-    if params[:name]
-      recipe = Recipe.new(params[:edamam_uri], params[:name])
-    else
-      recipe = Recipe.find_by_id(params[:id])
-    end
+    recipe = if params[:name]
+               Recipe.new(name: params[:name], edamam_id: params[:id])
+             else
+               Recipe.find_by_id(params[:id])
+             end
     if recipe
       @recipe = RecipesHelper.saved_recipe_from_api(recipe)
     else
-      # can redirect back to user dashboard once implemented
+      # can redirect back to user dashboard once implemented for favorites,
+      # user dashboard for saved recipes
       redirect_to action: 'show', id: 1, status: :not_found
     end
   end
@@ -18,6 +17,6 @@ class RecipesController < ApplicationController
   private
 
   def recipe_params
-    params.require(:recipe).permit(:name, :edamam_uri)
+    params.require(:recipe).permit(:name, :edamam_id)
   end
 end

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -3,7 +3,7 @@ module RecipesHelper
   require 'tasks/recipe_dto'
 
   def self.saved_recipe_from_api(recipe_data)
-    recipe_call = GetRecipe.new(recipe_data.edamam_uri)
+    recipe_call = GetRecipe.new(recipe_data.edamam_id)
     recipe = recipe_call.find_recipe[0]
     RecipeDto.new(recipe)
   end

--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -2,7 +2,7 @@ module RecipesHelper
   require 'tasks/get_recipe'
   require 'tasks/recipe_dto'
 
-  def self.saved_recipe_from_api(recipe_data)
+  def self.recipe_dto_from_api(recipe_data)
     recipe_call = GetRecipe.new(recipe_data.edamam_id)
     recipe = recipe_call.find_recipe[0]
     RecipeDto.new(recipe)

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -35,7 +35,7 @@
 
 <% if @recipes %>
   <% @recipes.each do |recipe| %>
-    <%= link_to name_recipe_path(recipe.make_dto.uri, recipe.make_dto.label) do %>
+    <%= link_to name_recipe_path(recipe.make_dto.e_id, recipe.make_dto.label) do %>
       <div>
         <%= image_tag(recipe.make_dto.image) %><br />
         <%= recipe.make_dto.label %><br />

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -35,11 +35,13 @@
 
 <% if @recipes %>
   <% @recipes.each do |recipe| %>
-    <div>
-      <%= image_tag(recipe.make_dto.image) %><br />
-      <%= recipe.make_dto.label %><br />
-      Calories per Serving: <%= (recipe.make_dto.calories/recipe.make_dto.yield).round(1) %>
-    </div>
-    <br /><br />
+    <%= link_to name_recipe_path(recipe.make_dto.uri, recipe.make_dto.label) do %>
+      <div>
+        <%= image_tag(recipe.make_dto.image) %><br />
+        <%= recipe.make_dto.label %><br />
+        Calories per Serving: <%= (recipe.make_dto.calories/recipe.make_dto.yield).round(1) %>
+      </div>
+      <br /><br />
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -2,7 +2,7 @@
 <%= image_tag(@recipe.image) %>
 <br /><br />
 
-<%= @recipe.label %>
+<%= @recipe.label %><br />
 <br /><br />
 
 Servings: <%= @recipe.yield %>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -2,7 +2,7 @@
 <%= image_tag(@recipe.image) %>
 <br /><br />
 
-<%= @recipe.label %><br />
+<%= @recipe.label %>
 <br /><br />
 
 Servings: <%= @recipe.yield %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'queries#index'
   post :search, controller: 'queries'
-  resources :recipes
+  resources :recipes do
+    member do
+      get ':name', to: 'recipes#show'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   post :search, controller: 'queries'
   resources :recipes do
     member do
-      get ':name', to: 'recipes#show'
+      get '(/:name)', to: 'recipes#show', as: 'name'
     end
   end
 end

--- a/db/migrate/20170720151416_rename_edamam_uri_to_id.rb
+++ b/db/migrate/20170720151416_rename_edamam_uri_to_id.rb
@@ -1,0 +1,5 @@
+class RenameEdamamUriToId < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :recipes, :edamam_uri, :edamam_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713141432) do
+ActiveRecord::Schema.define(version: 20170720151416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "recipes", force: :cascade do |t|
     t.string   "name"
-    t.string   "edamam_uri"
+    t.string   "edamam_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/tasks/get_recipe.rb
+++ b/lib/tasks/get_recipe.rb
@@ -7,7 +7,7 @@ class GetRecipe
   def initialize(edamam_uri)
     @options = {
       query: {
-        r: edamam_uri,
+        r: 'http://www.edamam.com/ontologies/edamam.owl#recipe_' + edamam_uri.to_s,
         app_id: ENV['app_id'],
         app_key: ENV['app_key']
       }

--- a/lib/tasks/get_recipe.rb
+++ b/lib/tasks/get_recipe.rb
@@ -4,10 +4,10 @@ class GetRecipe
   base_uri 'https://api.edamam.com'
   format :json
 
-  def initialize(edamam_uri)
+  def initialize(edamam_id)
     @options = {
       query: {
-        r: 'http://www.edamam.com/ontologies/edamam.owl#recipe_' + edamam_uri.to_s,
+        r: 'http://www.edamam.com/ontologies/edamam.owl#recipe_' + edamam_id.to_s,
         app_id: ENV['app_id'],
         app_key: ENV['app_key']
       }

--- a/lib/tasks/recipe_dto.rb
+++ b/lib/tasks/recipe_dto.rb
@@ -6,7 +6,7 @@ class RecipeDto
     self.image = json_object['image']
     self.ingredient_list = json_object['ingredientLines']
     self.label = json_object['label']
-    self.uri = json_object['uri']
+    self.uri = json_object['uri'].match(/_[[:alnum:]]*(\Z || \&)/).to_s[1..-1]
     self.url = json_object['url']
     self.yield = json_object['yield']
   end

--- a/lib/tasks/recipe_dto.rb
+++ b/lib/tasks/recipe_dto.rb
@@ -1,12 +1,12 @@
 class RecipeDto
-  attr_accessor :calories, :image, :ingredient_list, :label, :uri, :url, :yield
+  attr_accessor :calories, :e_id, :image, :ingredient_list, :label, :url, :yield
 
   def initialize(json_object)
     self.calories = json_object['calories']
     self.image = json_object['image']
     self.ingredient_list = json_object['ingredientLines']
     self.label = json_object['label']
-    self.uri = json_object['uri'].match(/_[[:alnum:]]*(\Z || \&)/).to_s[1..-1]
+    self.e_id = json_object['uri'].match(/_[[:alnum:]]*(\Z || \&)/).to_s[1..-1]
     self.url = json_object['url']
     self.yield = json_object['yield']
   end

--- a/spec/controllers/recipes_controller_spec.rb
+++ b/spec/controllers/recipes_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RecipesController, type: :controller do
     end
 
     it 'returns a success status if the recipe is found' do
-      allow(RecipesHelper).to receive(:saved_recipe_from_api)
+      allow(RecipesHelper).to receive(:recipe_dto_from_api)
         .with(eggplant).and_return(data_hash)
       get :show, params: { id: eggplant.id }
       expect(response).to have_http_status(:success)

--- a/spec/controllers/recipes_controller_spec.rb
+++ b/spec/controllers/recipes_controller_spec.rb
@@ -7,7 +7,7 @@ data_hash = JSON.parse(file)[0]
 RSpec.describe RecipesController, type: :controller do
   describe 'show' do
     subject(:eggplant) do
-      Recipe.create(name: 'Spicy Eggplant', edamam_uri:
+      Recipe.create(name: 'Spicy Eggplant', edamam_id:
       'http://www.edamam.com/ontologies/edamam.owl#recipe_a53ef6c8495adcb9f2859b1e5d99e9ba')
     end
 

--- a/spec/lib/tasks/recipe_dto_spec.rb
+++ b/spec/lib/tasks/recipe_dto_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe RecipeDto do
       expect(eggplant_dto.label).to eq(data_hash['label'])
     end
 
-    it 'creates an object with the recipe uri' do
-      expect(eggplant_dto.uri).to eq(data_hash['uri'])
+    it 'creates an object with the recipe id' do
+      expect(eggplant_dto.uri).to eq(data_hash['uri']
+      .match(/_[[:alnum:]]*(\Z || \&)/).to_s[1..-1])
     end
 
     it 'creates an object with the recipe url' do

--- a/spec/lib/tasks/recipe_dto_spec.rb
+++ b/spec/lib/tasks/recipe_dto_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RecipeDto do
     end
 
     it 'creates an object with the recipe id' do
-      expect(eggplant_dto.uri).to eq(data_hash['uri']
+      expect(eggplant_dto.e_id).to eq(data_hash['uri']
       .match(/_[[:alnum:]]*(\Z || \&)/).to_s[1..-1])
     end
 


### PR DESCRIPTION
- Renamed edamam_uri to edamam_id for routing purposes
- Created name_recipe route ( gets recipes#show) for unsaved recipe queries
- Recipe queries can now be clicked on queries#index to go to the recipe#show page for the unsaved recipe
