### PR TITLE
Empty query

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -28,10 +28,10 @@ class QueriesController < ApplicationController
   def search
     new_recipes = first_call
     if empty_query?
-      flash.now[:alert] = 'That\'s not a food!'
-      return
+      flash[:alert] = 'That\'s not a food!'
+    else
+      store(new_recipes.search)
     end
-    store(new_recipes.search)
     redirect_to queries_path
   end
 end

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -5,7 +5,7 @@ class QueriesController < ApplicationController
 
   def index
     return flash.now[:notice] = 'API limit reached' if
-    QueryResult.api_limit? || RecipeErrors.api_limit?
+      QueryResult.api_limit? || RecipeErrors.api_limit?
     return flash.now[:notice] = 'error' if QueryResult.query_error?
     return flash.now[:notice] = 'no recipe found' if QueryResult.no_recipe_found?
     return unless QueryResult.hits
@@ -27,6 +27,10 @@ class QueriesController < ApplicationController
 
   def search
     new_recipes = first_call
+    if empty_query?
+      flash.now[:alert] = 'That\'s not a food!'
+      return
+    end
     store(new_recipes.search)
     redirect_to queries_path
   end
@@ -38,6 +42,10 @@ def first_call
   GetRecipes.new(params[:q],
                  params[:max_cal],
                  params[:health])
+end
+
+def empty_query?
+  /^\s*$/ === params[:q].to_s
 end
 
 def store(recipe_search)

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -28,7 +28,7 @@ class QueriesController < ApplicationController
   def search
     new_recipes = first_call
     if empty_query?
-      flash[:alert] = 'That\'s not a food!'
+      flash[:alert] = 'Please enter an actual food'
     else
       store(new_recipes.search)
     end

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -28,7 +28,7 @@ class QueriesController < ApplicationController
   def search
     new_recipes = first_call
     if empty_query?
-      flash[:alert] = 'Please enter an actual food'
+      flash[:alert] = 'Oops! Looks like the search field was empty, please try again!'
     else
       store(new_recipes.search)
     end
@@ -45,7 +45,7 @@ def first_call
 end
 
 def empty_query?
-  /^\s*$/ === params[:q].to_s
+  /^\s*$/ =~ params[:q].to_s
 end
 
 def store(recipe_search)

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -1,7 +1,3 @@
-<div>
-  <%= flash[:alert] if flash[:alert] %>
-</div>
-
 <div class="form-container">
 <%= render 'search_form' %>
 </div>

--- a/app/views/queries/index.html.erb
+++ b/app/views/queries/index.html.erb
@@ -1,3 +1,7 @@
+<div>
+  <%= flash[:alert] if flash[:alert] %>
+</div>
+
 <div class="form-container">
 <%= render 'search_form' %>
 </div>


### PR DESCRIPTION
- API call is prevented for empty query
- Flash message displays when empty query is searched

Things to think about:
- Text of the flash message
- Page still refreshed on clicking of search button (not the prettiest, but this is also what happens for 'no recipe found.' Can be changed?)