### PR TITLE
Change like/dislike buttons to use button_to

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -5,6 +5,10 @@
   position: relative;
 }
 
+.button-row-container form {
+  display: inline-block;
+}
+
 .button {
   border: 2px solid #8a8a8a;
   background-color: transparent;

--- a/app/views/queries/_buttons.html.erb
+++ b/app/views/queries/_buttons.html.erb
@@ -22,7 +22,7 @@
                 <i class="fa fa-thumbs-down"></i>
             <% end %>
           <% else %>
-            <%= link_to recipes_path(user_id: current_user.id,
+            <%= button_to recipes_path(user_id: current_user.id,
                                           id: recipe.e_id,
                                           recipe_name: recipe.label,
                                           dislike: false,
@@ -32,7 +32,7 @@
                                           method: :post do %>
                 <i class="fa fa-heart-o"></i>
             <% end %>
-            <%= link_to recipes_path(user_id: current_user.id,
+            <%= button_to recipes_path(user_id: current_user.id,
                                           id: recipe.e_id,
                                           recipe_name: recipe.label,
                                           dislike: true,


### PR DESCRIPTION
For like/dislike buttons, change link_to to button_to in an attempt to prevent opening of new tab on iPhone safari browsers.