### PR TITLE
Attempt to fix iOS :active issue

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="row align-center">
     <div class="small-12 medium-12 large-5 column center-text">
-        <div class="profile-wrap">
+        <div class="profile-wrap" ontouchstart="">
           <div class="pulse1"></div>
           <div class="pulse2"></div>
           <div class="profile-overlay"></div>
@@ -29,7 +29,7 @@
         </div>
     </div>
     <div class="small-12 medium-12 large-5 column center-text">
-      <div class="profile-wrap">
+      <div class="profile-wrap" ontouchstart="">
         <div class="pulse1"></div>
         <div class="pulse2"></div>
         <div class="profile-overlay"></div>


### PR DESCRIPTION
Safari mobile does not register :hover or :active (unless for a link). This fix will hopefully allow the about profile photos to change when clicked.

[https://stackoverflow.com/questions/3885018/active-pseudo-class-doesnt-work-in-mobile-safari](url)