### PR TITLE
Fix shoulda-matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,7 @@ group :development do
 end
 
 group :test do
-  gem 'shoulda-matchers', git: 'https://github.com/thoughtbot/shoulda-matchers.git',
-                          branch: 'rails-5'
+  gem 'shoulda-matchers', '~> 3.1'
   gem 'webmock', '~> 2.3', '>= 2.3.2'
 
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: edaf9cb926ee9c59c59729e7a4f8c206b44da8a1
-  branch: rails-5
-  specs:
-    shoulda-matchers (3.1.2)
-      activesupport (>= 4.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -221,6 +213,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
@@ -299,7 +293,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   rubocop (~> 0.49.1)
   sass-rails (~> 5.0)
-  shoulda-matchers!
+  shoulda-matchers (~> 3.1)
   simple_form
   simplecov
   spring
@@ -311,4 +305,4 @@ DEPENDENCIES
   will_paginate (~> 3.1.1)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.2


### PR DESCRIPTION
Shoulda matchers gem must have updated & was causing errors with bundle install. Updated gem according to new installation instructions.